### PR TITLE
update info command and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,78 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-* [`oclif-example hello [FILE]`](#oclif-example-hello-file)
+* [`oclif-example data:cdc:create`](#oclif-example-datacdccreate)
+* [`oclif-example data:cdc:destroy [CONNECTOR]`](#oclif-example-datacdcdestroy-connector)
+* [`oclif-example data:cdc:info [CDCID]`](#oclif-example-datacdcinfo-cdcid)
+* [`oclif-example data:cdc:wait [CONNECTOR]`](#oclif-example-datacdcwait-connector)
 
-## `oclif-example hello [FILE]`
+## `oclif-example data:cdc:create`
 
-describe the command here
+create a new Postgres Connector attached to your Kafka cluster
 
 ```
 USAGE
-  $ oclif-example hello [FILE]
+  $ oclif-example data:cdc:create
 
 OPTIONS
-  -f, --force
-  -h, --help       show CLI help
-  -n, --name=name  name to print
+  -a, --app=app      app to run command against
+  -t, --table=table  (required) Tables to include
+  --exclude=exclude  Columns to exclude
+  --source=source    (required) The name or ID of the Postgres instance whose change data you want to store
+  --store=store      (required) The name or ID of the Kafka instance that will store the change data
 
-EXAMPLE
-  $ oclif-example hello
-  hello world from ./src/hello.ts!
+EXAMPLES
+  $ heroku data:cdc:create --store kafka-lovely-12345 --source postgresql-neato-98765 --table public.posts --table 
+  public.comments
+  $ heroku data:cdc:create --store kafka-lovely-12345 --source postgresql-neato-98765 --table public.users --exclude 
+  public.users.password
 ```
 
-_See code: [src/commands/hello.ts](https://github.com/heroku/heroku-change-data-capture/blob/v0.0.0/src/commands/hello.ts)_
+_See code: [src/commands/data/cdc/create.ts](https://github.com/heroku/heroku-change-data-capture/blob/v0.0.0/src/commands/data/cdc/create.ts)_
+
+## `oclif-example data:cdc:destroy [CONNECTOR]`
+
+destroy a Postgres Connector
+
+```
+USAGE
+  $ oclif-example data:cdc:destroy [CONNECTOR]
+
+EXAMPLE
+  $ heroku data:cdc:destroy gentle-connector-1234
+```
+
+_See code: [src/commands/data/cdc/destroy.ts](https://github.com/heroku/heroku-change-data-capture/blob/v0.0.0/src/commands/data/cdc/destroy.ts)_
+
+## `oclif-example data:cdc:info [CDCID]`
+
+get information about a CDC Connection
+
+```
+USAGE
+  $ oclif-example data:cdc:info [CDCID]
+
+OPTIONS
+  --json  output in json format
+
+EXAMPLES
+  $ heroku cdc ad2a0126-aee2-4815-8e95-8367e3a2984b
+  $ heroku cdc ad2a0126-aee2-4815-8e95-8367e3a2984b --json
+```
+
+_See code: [src/commands/data/cdc/info.ts](https://github.com/heroku/heroku-change-data-capture/blob/v0.0.0/src/commands/data/cdc/info.ts)_
+
+## `oclif-example data:cdc:wait [CONNECTOR]`
+
+wait for your Postgres Connector to be provisioned
+
+```
+USAGE
+  $ oclif-example data:cdc:wait [CONNECTOR]
+
+EXAMPLE
+  $ heroku data:cdc:wait gentle-connector-1234
+```
+
+_See code: [src/commands/data/cdc/wait.ts](https://github.com/heroku/heroku-change-data-capture/blob/v0.0.0/src/commands/data/cdc/wait.ts)_
 <!-- commandsstop -->

--- a/src/commands/data/cdc/info.ts
+++ b/src/commands/data/cdc/info.ts
@@ -7,8 +7,6 @@ import BaseCommand, {PostgresConnector} from '../../../lib/base'
 export default class CdcInfo extends BaseCommand {
   static description = 'get information about a CDC Connection'
 
-  static aliases = ['data:cdc:info']
-
   static examples = [
     '$ heroku cdc ad2a0126-aee2-4815-8e95-8367e3a2984b',
     '$ heroku cdc ad2a0126-aee2-4815-8e95-8367e3a2984b --json',


### PR DESCRIPTION
Changed the index command to specifically be `info` in preparation for having `data:cdc` list all connectors.

Also added commands to the readme