### PR TITLE
output valid json if json flag is used

### DIFF
--- a/src/commands/data/connectors/index.ts
+++ b/src/commands/data/connectors/index.ts
@@ -75,6 +75,14 @@ export default class ConnectorsList extends BaseCommand {
       cli.error('You must pass either the --app or --addon flag')
     }
 
+    if (flags.json) {
+      connectorInfo.forEach(v => {
+        cli.styledJSON(v)
+        this.log()
+      })
+      return
+    }
+
     cli.styledHeader(`Data Connector info for ${flags.app || flags.addon}`)
 
     if (flags.table) {
@@ -88,11 +96,6 @@ export default class ConnectorsList extends BaseCommand {
           header: 'Postgres Add-On',
           get: row => row.name,
         },
-      })
-    } else if (flags.json) {
-      connectorInfo.forEach(v => {
-        cli.styledJSON(v)
-        this.log()
       })
     } else {
       connectorInfo.forEach(v => {


### PR DESCRIPTION
BEFORE
```
⇒ h data:connectors --json -a app
=== Data Connector info for app
{
  "uuid": <snip>
```

AFTER
```
⇒ h data:connectors --json -a app             
{
  "uuid": <snip>
```

With this change, the user can use tools like `jq` to parse the output properly.