### PR TITLE
fix table output for connector list

### DIFF
--- a/src/commands/data/connectors/index.ts
+++ b/src/commands/data/connectors/index.ts
@@ -90,11 +90,11 @@ export default class ConnectorsList extends BaseCommand {
         name: {header: 'Connector Name'},
         kafka_addon: {
           header: 'Kafka Add-On',
-          get: row => row.name,
+          get: row => row.kafka_addon.name,
         },
         postgres_addon: {
           header: 'Postgres Add-On',
-          get: row => row.name,
+          get: row => row.postgres_addon.name,
         },
       })
     } else {

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -94,13 +94,13 @@ Postgres Add-On: postgresql-rectangular-10992`
     .command(['data:connectors', `--app=${appName}`, '--table'])
     .it('returns the correct table output', ctx => {
       const expectedOutput = `=== Data Connector info for ${appName}
-Connector Name                            Kafka Add-On       Postgres Add-On
+Connector Name Kafka Add-On Postgres Add-On
 pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992
 pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992`
 
       const actualOutput = ctx.stdout
       expectedOutput.split('\n').forEach(expectedLine => {
-        expect(actualOutput).to.include(expectedLine.trim())
+        expect(actualOutput).to.include(expectedLine.trim().replace(/\s+/g, ' '))
       })
     })
   })

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -76,6 +76,33 @@ Postgres Add-On: postgresql-rectangular-10992`
         expect(expectedOutput).to.include(v.trim())
       })
     })
+
+    test
+    .nock('https://api.heroku.com', api => {
+      api
+      .get(`/apps/${appName}`)
+      .reply(200, {
+        id: appId,
+      })
+    })
+    .nock('https://postgres-api.heroku.com', api => {
+      api
+      .get(`/data/cdc/v0/apps/${appId}`)
+      .reply(200, connectorList)
+    })
+    .stdout()
+    .command(['data:connectors', `--app=${appName}`, '--table'])
+    .it('returns the correct table output', ctx => {
+      const expectedOutput = `=== Data Connector info for ${appName}
+Connector Name                            Kafka Add-On       Postgres Add-On
+pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992
+pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992`
+
+      const actualOutput = ctx.stdout
+      expectedOutput.split('\n').forEach(expectedLine => {
+        expect(actualOutput).to.include(expectedLine.trim())
+      })
+    })
   })
 
   describe('using the addon flag', () => {

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -101,6 +101,7 @@ pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangu
       const actualOutput = ctx.stdout.split('\n').map(line => {
         return line.replace(/\s+/g, ' ').trim()
       })
+      expect(actualOutput[2]).to.eq('pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992')
       expectedOutput.split('\n').forEach(expectedLine => {
         expect(actualOutput).to.include(expectedLine.replace(/\s+/g, ' ').trim())
       })

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -23,7 +23,7 @@ const connectorList = [
       uuid: '677abc7a-839a-4589-86c3-e0a28a882690',
     },
     uuid: '123456',
-    name: 'pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a',
+    name: 'brave-connector-35864',
   },
   {
     kafka_app: {
@@ -41,7 +41,7 @@ const connectorList = [
       uuid: '677abc7a-839a-4589-86c3-e0a28a882690',
     },
     uuid: '123456',
-    name: 'pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a',
+    name: 'brave-connector-35864',
   },
 ]
 
@@ -64,11 +64,11 @@ describe('data:connectors', () => {
     .command(['data:connectors', `--app=${appName}`])
     .it('returns the correct output', ctx => {
       const expectedOutput = `=== Data Connector info for ${appName}
-Connector Name:  pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a
+Connector Name:  brave-connector-35864
 Kafka Add-On:    kafka-metric-96658
 Postgres Add-On: postgresql-rectangular-10992
 
-Connector Name:  pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a
+Connector Name:  brave-connector-35864
 Kafka Add-On:    kafka-metric-96658
 Postgres Add-On: postgresql-rectangular-10992`
 
@@ -95,13 +95,13 @@ Postgres Add-On: postgresql-rectangular-10992`
     .it('returns the correct table output', ctx => {
       const expectedOutput = `=== Data Connector info for ${appName}
 Connector Name Kafka Add-On Postgres Add-On
-pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992
-pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992`
+brave-connector-35864 kafka-metric-96658 postgresql-rectangular-10992
+brave-connector-35864 kafka-metric-96658 postgresql-rectangular-10992`
 
       const actualOutput = ctx.stdout.split('\n').map(line => {
         return line.replace(/\s+/g, ' ').trim()
       })
-      expect(actualOutput[2]).to.eq('pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992')
+      expect(actualOutput[2]).to.eq('brave-connector-35864 kafka-metric-96658 postgresql-rectangular-10992')
       expectedOutput.split('\n').forEach(expectedLine => {
         expect(actualOutput).to.include(expectedLine.replace(/\s+/g, ' ').trim())
       })
@@ -128,11 +128,11 @@ pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangu
     .command(['data:connectors', `--addon=${kafkaName}`])
     .it('returns the correct output', ctx => {
       const expectedOutput = `=== Data Connector info for ${kafkaName}
-Connector Name:  pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a
+Connector Name:  brave-connector-35864
 Kafka Add-On:    kafka-metric-96658
 Postgres Add-On: postgresql-rectangular-10992
 
-Connector Name:  pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a
+Connector Name:  brave-connector-35864
 Kafka Add-On:    kafka-metric-96658
 Postgres Add-On: postgresql-rectangular-10992`
 

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -101,7 +101,6 @@ brave-connector-35864 kafka-metric-96658 postgresql-rectangular-10992`
       const actualOutput = ctx.stdout.split('\n').map(line => {
         return line.replace(/\s+/g, ' ').trim()
       })
-      expect(actualOutput[2]).to.eq('brave-connector-35864 kafka-metric-96658 postgresql-rectangular-10992')
       expectedOutput.split('\n').forEach(expectedLine => {
         expect(actualOutput).to.include(expectedLine.replace(/\s+/g, ' ').trim())
       })

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -98,7 +98,7 @@ Connector Name Kafka Add-On Postgres Add-On
 pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992
 pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992`
 
-      const actualOutput = ctx.stdout
+      const actualOutput = ctx.stdout.replace(/ +/g, ' ')
       expectedOutput.split('\n').forEach(expectedLine => {
         expect(actualOutput).to.include(expectedLine.trim().replace(/\s+/g, ' '))
       })

--- a/test/commands/connectors/index.test.ts
+++ b/test/commands/connectors/index.test.ts
@@ -98,9 +98,11 @@ Connector Name Kafka Add-On Postgres Add-On
 pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992
 pg2k_a9cc07b4_2a8c_438d_8e54_db08073e5a9a kafka-metric-96658 postgresql-rectangular-10992`
 
-      const actualOutput = ctx.stdout.replace(/ +/g, ' ')
+      const actualOutput = ctx.stdout.split('\n').map(line => {
+        return line.replace(/\s+/g, ' ').trim()
+      })
       expectedOutput.split('\n').forEach(expectedLine => {
-        expect(actualOutput).to.include(expectedLine.trim().replace(/\s+/g, ' '))
+        expect(actualOutput).to.include(expectedLine.replace(/\s+/g, ' ').trim())
       })
     })
   })


### PR DESCRIPTION
Fixes an issue with the `--table` output for the connector list, where the connector name was displayed for the addon names.

Before
```
$ myh data:connectors -a jwadsworth-cdc-demo --table
=== Data Connector info for jwadsworth-cdc-demo
Connector Name                Kafka Add-On                  Postgres Add-On
brave-connector-35864         brave-connector-35864         brave-connector-35864
compassionate-connector-28060 compassionate-connector-28060 compassionate-connector-28060
witty-connector-52805         witty-connector-52805         witty-connector-52805
```

After
```
$ myh data:connectors -a jwadsworth-cdc-demo --table
=== Data Connector info for jwadsworth-cdc-demo
Connector Name                Kafka Add-On                  Postgres Add-On
brave-connector-35864         kafka-jwadsworth-closed-22210 postgresql-jwadsworth-vertical-35475
compassionate-connector-28060 kafka-jwadsworth-closed-22210 postgresql-jwadsworth-vertical-35475
witty-connector-52805         kafka-jwadsworth-closed-22210 postgresql-jwadsworth-tetrahedral-40080
```