### PR TITLE
Add note about kafka topic deletion

### DIFF
--- a/src/commands/data/connectors/destroy.ts
+++ b/src/commands/data/connectors/destroy.ts
@@ -35,6 +35,7 @@ export default class ConnectorsDestroy extends BaseCommand {
     try {
       await this.shogun.delete<PostgresConnector>(`/data/cdc/v0/connectors/${connector}`, this.shogun.defaults)
       this.log(`Data Connector ${connector} deleted successfully.`)
+      this.log('Note: We do not delete your Kafka topics automatically, because they could still contain messages which you haven\'t consumed. Please delete the topics manually. See heroku kafka:topics:destroy --help')
     } catch (error) {
       this.warn('There was an issue deleting your Data Connector.')
       throw error

--- a/test/commands/connectors/destroy.test.ts
+++ b/test/commands/connectors/destroy.test.ts
@@ -19,6 +19,7 @@ describe('data:connectors:destroy', () => {
   .it('works', ctx => {
     const expectedOutput = `Data Connector ${connectorId} deleted successfully.`
     expect(ctx.stdout.trim()).to.include(expectedOutput)
+    expect(ctx.stdout.trim()).to.include('Note: We do not delete your Kafka topics automatically, because they could still contain messages which you haven\'t consumed. Please delete the topics manually. See heroku kafka:topics:destroy --help')
   })
 
   test


### PR DESCRIPTION
We do not automatically delete the kafka topics that were used by the connector. Show a note to users when they delete a connector to make them aware of this.