### PR TITLE
resolve addon names to IDs; then use IDs for shogun API

### DIFF
--- a/src/commands/data/connectors/create.ts
+++ b/src/commands/data/connectors/create.ts
@@ -1,7 +1,7 @@
 import color from '@heroku-cli/color'
 import {flags} from '@heroku-cli/command'
 import {cli} from 'cli-ux'
-import {addon as fetchAddon} from '../../../fetcher'
+import {fetchAddon} from '../../../fetcher'
 
 import BaseCommand, {PostgresConnector} from '../../../lib/base'
 

--- a/src/commands/data/connectors/create.ts
+++ b/src/commands/data/connectors/create.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {flags} from '@heroku-cli/command'
 import {cli} from 'cli-ux'
+import {addon as fetchAddon} from '../../../fetcher'
 
 import BaseCommand, {PostgresConnector} from '../../../lib/base'
 
@@ -8,13 +9,14 @@ export default class ConnectorsCreate extends BaseCommand {
   static description = 'create a new Data Connector\nRead more about this feature at https://devcenter.heroku.com/articles/heroku-data-connectors'
 
   static flags = {
+    app: flags.app(),
     source: flags.string({
       required: true,
-      description: 'The name or ID of the database instance whose change data you want to store',
+      description: 'The name of the database add-on whose change data you want to store',
     }),
     store: flags.string({
       required: true,
-      description: 'The name or ID of the database instance that will store the change data',
+      description: 'The name of the database add-on that will store the change data',
     }),
     name: flags.string({
       required: false,
@@ -44,17 +46,19 @@ export default class ConnectorsCreate extends BaseCommand {
 
   async run() {
     const {flags} = this.parse(ConnectorsCreate)
-    const {source: postgres, store: kafka} = flags
     const tables = flags.table
     const excluded = flags.exclude || []
     const platformVersion = flags['platform-version'] || ''
     const name = flags.name || ''
+    const kafka = await fetchAddon(this.heroku, flags.store, flags.app)
+    const postgres = await fetchAddon(this.heroku, flags.source, flags.app)
 
     cli.action.start('Provisioning Data Connector')
-    const {body: res} = await this.shogun.post<PostgresConnector>(`/data/cdc/v0/kafka_tenants/${kafka}`, {
+
+    const {body: res} = await this.shogun.post<PostgresConnector>(`/data/cdc/v0/kafka_tenants/${kafka.id}`, {
       ...this.shogun.defaults,
       body: {
-        postgres_addon_uuid: postgres,
+        postgres_addon_uuid: postgres.id,
         tables,
         excluded_columns: excluded,
         platform_version: platformVersion,

--- a/src/commands/data/connectors/index.ts
+++ b/src/commands/data/connectors/index.ts
@@ -1,7 +1,7 @@
 import {flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {cli} from 'cli-ux'
-import {addon as fetchAddon} from '../../../fetcher'
+import {fetchAddon} from '../../../fetcher'
 import BaseCommand, {PostgresConnector} from '../../../lib/base'
 
 type ConnectorInfo = Pick<

--- a/src/commands/data/connectors/index.ts
+++ b/src/commands/data/connectors/index.ts
@@ -1,6 +1,7 @@
 import {flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {cli} from 'cli-ux'
+import {addon as fetchAddon} from '../../../fetcher'
 import BaseCommand, {PostgresConnector} from '../../../lib/base'
 
 type ConnectorInfo = Pick<
@@ -49,7 +50,14 @@ export default class ConnectorsList extends BaseCommand {
 
     let connectorInfo: Array<ConnectorInfo>
 
-    if (flags.app) {
+    if (flags.addon) {
+      const addon = await fetchAddon(this.heroku, flags.addon, flags.app)
+      const {body: response} = await this.shogun.get<Array<ConnectorInfo>>(
+        `/data/cdc/v0/addons/${addon.id}`,
+        this.shogun.defaults
+      )
+      connectorInfo = response
+    } else if (flags.app) {
       // make sure we have app id even if they passed app name
       const {body: app} = await this.heroku.get<Heroku.App>(`/apps/${flags.app}`)
 
@@ -59,20 +67,6 @@ export default class ConnectorsList extends BaseCommand {
       )
 
       connectorInfo = response.body
-    } else if (flags.addon) {
-      // make sure we have addon id even if the addon name
-      const {body: [addon]} =  await this.heroku.post<Array<Heroku.AddOn>>('/actions/addons/resolve', {
-        body: {
-          addon: flags.addon,
-        },
-      })
-
-      const {body: response} = await this.shogun.get<Array<ConnectorInfo>>(
-        `/data/cdc/v0/addons/${addon.id}`,
-        this.shogun.defaults
-      )
-
-      connectorInfo = response
     } else {
       cli.error('You must pass either the --app or --addon flag')
     }

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,7 +1,7 @@
 import * as Heroku from '@heroku-cli/schema'
 import {APIClient} from '@heroku-cli/command'
 
-export async function addon(heroku: APIClient, addon: string, app?: string) {
+export async function fetchAddon(heroku: APIClient, addon: string, app?: string) {
   const {body: result} = await heroku.post<Heroku.AddOn[]>('/actions/addons/resolve', {
     body: {
       app,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,0 +1,21 @@
+import * as Heroku from '@heroku-cli/schema'
+import {APIClient} from '@heroku-cli/command'
+
+export async function addon(heroku: APIClient, addon: string, app?: string) {
+  const {body: result} = await heroku.post<Heroku.AddOn[]>('/actions/addons/resolve', {
+    body: {
+      app,
+      addon,
+    }},
+  )
+
+  if (result.length > 1) {
+    if (app === undefined) {
+      throw new Error('Unable to determine addon, try including an app')
+    } else {
+      throw new Error('Unable to determine addon')
+    }
+  }
+
+  return result[0]
+}

--- a/test/commands/connectors/create.test.ts
+++ b/test/commands/connectors/create.test.ts
@@ -1,6 +1,8 @@
 import {expect, test} from '@oclif/test'
 
+const kafkaName = 'kafka-metric-96658'
 const kafkaId = 'abcdef'
+const postgresName = 'postgresql-satirical-36423'
 const postgresId = '123456'
 
 const kafkaTenant = {
@@ -19,6 +21,24 @@ const kafkaTenant = {
 describe('data:connectors:create', () => {
   const expectedOutput = 'Run heroku data:connectors:wait new-cdc-connector to check the creation process.'
   test
+  .nock('https://api.heroku.com', api => {
+    api
+    .post('/actions/addons/resolve', {
+      addon: kafkaName,
+    })
+    .reply(200, [{
+      id: kafkaId,
+    }])
+  })
+  .nock('https://api.heroku.com', api => {
+    api
+    .post('/actions/addons/resolve', {
+      addon: postgresName,
+    })
+    .reply(200, [{
+      id: postgresId,
+    }])
+  })
   .nock('https://postgres-api.heroku.com', api => {
     api
     .post(`/data/cdc/v0/kafka_tenants/${kafkaId}`, kafkaTenant)
@@ -29,8 +49,8 @@ describe('data:connectors:create', () => {
   .stdout()
   .command([
     'data:connectors:create',
-    `--store=${kafkaId}`,
-    `--source=${postgresId}`,
+    `--store=${kafkaName}`,
+    `--source=${postgresName}`,
     '--table=public.foo',
     '--table=public.bar',
     '--exclude=public.foo.column1',


### PR DESCRIPTION
Adds the addon fetcher (cribbed from another data plugin) to get an addon by name or attachment name. The index and create commands have been updated to use this fetcher, then to make calls to the shogun APIs using the addon UUIDs.

This gives us better error messages when we have a plan mismatch, and cleans up some deprecation rollbars in shogun.

https://gus.lightning.force.com/a07B00000089aluIAA